### PR TITLE
Decided to keep .ToCompoundUnit() as it is

### DIFF
--- a/Extensions/CompoundUnitExtensions.cs
+++ b/Extensions/CompoundUnitExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Commons.Physics;
 
@@ -8,7 +7,7 @@ namespace Commons.Extensions
     public static class CompoundUnitExtensions
     {
         private static readonly Dictionary<CompoundUnit, Unit> CompoundUnitToUnitMap =
-            ((Unit[]) Enum.GetValues(typeof(Unit))).Where(unit => unit.IsSIUnit()).ToDictionary(x => x.ToCompoundUnit(), x => x);
+            EnumExtensions.GetValues<Unit>().Where(unit => unit.IsSIUnit()).ToDictionary(x => x.ToCompoundUnit(), x => x);
 
         public static Unit ToUnit(this CompoundUnit unit)
         {

--- a/Physics/CompoundUnit.cs
+++ b/Physics/CompoundUnit.cs
@@ -55,8 +55,12 @@ namespace Commons.Physics
 
         public override bool Equals(object other)
         {
-            if (other is Unit)
-                return Equals(((Unit) other).ToSIUnit().ToCompoundUnit());
+            if (other is Unit unit)
+            {
+                if (!unit.IsSIUnit())
+                    return false;
+                return Equals(unit.ToSIUnit().ToCompoundUnit());
+            }
             return Equals(other as CompoundUnit);
         }
 

--- a/Physics/UnitConverter.cs
+++ b/Physics/UnitConverter.cs
@@ -69,6 +69,7 @@ namespace Commons.Physics
 
         public static bool IsSIUnit(this Unit unit)
         {
+            // Units that are directly representable by compound unit without value conversion
             return unit.InSet(
                 Unit.Meter,
                 Unit.MetersPerSecond,
@@ -163,6 +164,8 @@ namespace Commons.Physics
                     return new UnitConversionResult(Unit.CubicMeters, value * 0.001);
                 case Unit.Gram:
                     return new UnitConversionResult(Unit.Kilogram, value * 0.001);
+
+                // SI-units. Needs to match .IsSIUnit()-list
                 case Unit.Meter:
                 case Unit.MetersPerSecond:
                 case Unit.MetersPerSecondSquared:

--- a/Physics/UnitValueParser.cs
+++ b/Physics/UnitValueParser.cs
@@ -26,9 +26,7 @@ namespace Commons.Physics
             {
                 ParseSimpleUnit(unitString, out var simpleUnit, out var siPrefix);
                 var unitConversionResult = value.ConvertToSI(simpleUnit);
-                var multiplier = siPrefix.GetMultiplier();
-                unit = unitConversionResult.Unit.ToCompoundUnit();
-                value = multiplier * unitConversionResult.Value;
+                return unitConversionResult.Value.To(siPrefix, unitConversionResult.Unit);
             }
             catch (FormatException)
             {


### PR DESCRIPTION
… with constraint to SI-units (which do not require value conversion)